### PR TITLE
Allow array-valued parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ using either:
 * [W3C's ReSpec web service](https://github.com/w3c/spec-generator).
 
 When constructing the URL, `params` are rendered as if they were [mustache template strings](https://github.com/janl/mustache.js#mustachejs---logic-less-mustache-templates-with-javascript).
+You can also use an array of strings, instead of a string, to pass multiple values for the same query parameter.
 
 They're passed an object containing the `config` object itself,
 the [`pull_request` payload](https://developer.github.com/v3/pulls/#get-a-single-pull-request)
@@ -113,7 +114,7 @@ to produce [this snapshot](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw
         "md-h1": "URL <small>(<a href=\"{{ pull_request.html_url }}\">PR #{{ pull_request.number }}</a>)</small>",
         "md-warning": "Commit {{ short_sha }} {{ pull_request.head.repo.html_url }}/commit/{{ sha }} replaced by {{ config.ls_url }}",
         "md-title": "{{ config.title }} (Pull Request Snapshot #{{ pull_request.number }})",
-        "md-Text-Macro": "SNAPSHOT-LINK {{ config.back_to_ls_link }}"
+        "md-Text-Macro": ["SNAPSHOT-LINK {{ config.back_to_ls_link }}", "COMMIT-SHA {{ sha }}"]
     },
     "ls_url": "https://url.spec.whatwg.org/",
     "title": "URL Standard",

--- a/lib/mixins/fetchable.js
+++ b/lib/mixins/fetchable.js
@@ -72,9 +72,15 @@ module.exports = (superclass) => class extends superclass {
     getQuery(data, encode) {
         let params = this.pr.config.params || {};
         return Object.keys(params).map(k => {
-            let tmpl = String(params[k]);
-            let v = mustache.render(tmpl, data);
-            return `${ k }=${ encode ? urlencode(v) : v }`;
+            if (!Array.isArray(params[k])) {
+                params[k] = [params[k]];
+            }
+
+            return params[k].map(value => {
+                let tmpl = String(value);
+                let v = mustache.render(tmpl, data);
+                return `${ k }=${ encode ? urlencode(v) : v }`;
+            }).join("&");
         }).join("&");
     }
 


### PR DESCRIPTION
See https://github.com/whatwg/whatwg.org/pull/310#issuecomment-607501868 for context.

I wasn't sure where to add tests for this. You pointed me to https://github.com/tobie/pr-preview/blob/master/test/models/config.js but that doesn't include the Fetchable mixin, and Config doesn't have Fetchable mixed in. I could add a new `test/mixins/` folder?