### PR TITLE
Document that w3ctag has a blanket install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ is all you need to be setup if your repository is hosted in one of them:
 * [github.com/w3c](https://github.com/w3c/)
 * [github.com/whatwg](https://github.com/whatwg/)
 * [github.com/wicg](https://github.com/wicg/)
+* [github.com/w3ctag](https://github.com/w3ctag/)
 
 ## Configuration file
 


### PR DESCRIPTION
I just configured the w3ctag organization to have a blanket install, as noted in https://github.com/w3ctag/security-questionnaire/pull/74#issuecomment-624271046, so I figured I may as well document that here.