### PR TITLE
Update .travis.yml: Node 6 is really old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - "6.11.1"
+  - "lts/*"


### PR DESCRIPTION
Dunno if this is exactly what you want, but 6.11.1 definitely isn't. :)

See https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions.