### PR TITLE
Fix CI/CD pipeline by moving to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: '12.x'
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "lts/*"


### PR DESCRIPTION
This PR tries to close #94 by moving from Travis CI to GitHub Actions.

### Background

Currently CI/CD pipeline of this repository is stopped because travis-ci.org is [ceased in June 2021](https://blog.travis-ci.com/2021-05-07-orgshutdown). Travis recommends to migrate to travis-ci.com, but it is essentially paid-for. To receive free OSS credits, you have to [place a validated request](https://docs.travis-ci.com/user/billing-faq/#what-if-i-am-building-open-source) with their support team.

GitHub Actions seems to be a good place to migrate to. It is [free for public repositories](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), and is adopted by many projects. Its configuration file is relatively simple and easy to install.

### Demo

- `npm test` passes: vzvu3k6k/pr-preview#4
- `npm test` fails: vzvu3k6k/pr-preview#3