### PR TITLE
spec-generator now supports respec documents served on raw.githubusercontent.com

### DIFF
--- a/lib/mixins/fetchable.js
+++ b/lib/mixins/fetchable.js
@@ -46,7 +46,7 @@ module.exports = (superclass) => class extends superclass {
 
     getRespecUrl(data) {
         let query = this.getQuery(data, "?");
-        return `https://labs.w3.org/spec-generator/?type=respec&url=${urlencode(this.cdn_url + query)}`
+        return `https://labs.w3.org/spec-generator/?type=respec&url=${urlencode(this.github_url + query)}`
     }
 
     getHtmlUrl(data) {

--- a/test/models/branch.js
+++ b/test/models/branch.js
@@ -95,7 +95,7 @@ suite("Branch model", function() {
         assert.equal(b.sha, "2eb8839fcbc6f04cae8fede477ced39cdbb07329");
     });
 
-    const RESPEC_URL = "https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Ftobie%2Fwebidl%2F7dfd134ee2e6df7fe0af770783a6b76a3fc56867%2F";
+    const RESPEC_URL = "https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Ftobie%2Fwebidl%2F7dfd134ee2e6df7fe0af770783a6b76a3fc56867%2F";
 
     test("Test getUrl", function() {
         let pr = new PR("heycam/webidl/283", { id: 234 });


### PR DESCRIPTION
@jyasskin suggested that having the spec-generator support documents on raw.githubusercontent.com would remove the need for githack. This is now done, e.g. https://labs.w3.org/spec-generator/?type=respec&url=https://raw.githubusercontent.com/w3c/iip/gh-pages/gap-analysis/taml-gap.html?specStatus=WD&shortName=taml-gap

Fix #112 