### PR TITLE
scanIncludes: make includes relative to spec directory

### DIFF
--- a/lib/scan-includes.js
+++ b/lib/scan-includes.js
@@ -77,7 +77,7 @@ module.exports = async function scanIncludes(repositoryUrl, rootSpec, specType, 
      * the fetch worked, and then recursively scans any includes found in the
      * response.
      */
-    async function scanOneFile(path) {
+    async function scanOneFile(path, specDir) {
         if (everFetched.has(path)) return;
         everFetched.add(path);
 
@@ -99,11 +99,13 @@ module.exports = async function scanIncludes(repositoryUrl, rootSpec, specType, 
         // Intentionally serial since Node's treatment of connection pooling is
         // hard to figure out from the documentation:
         for (const match of body.matchAll(includeRE)) {
-            await scanOneFile(match[1].trim());
+            await scanOneFile(specDir + match[1].trim(), specDir);
         }
     }
     console.log(`scanIncludes: Recursively scanning ${rootSpec} in ${repositoryUrl} for includes.`)
-    await scanOneFile(rootSpec);
+    // Includes are relative to the root spec file.
+    const specDir = rootSpec.substring(0, rootSpec.lastIndexOf('/') + 1);
+    await scanOneFile(rootSpec, specDir);
 
     recursiveIncludes.delete(rootSpec);
     console.log(`scanIncludes: Found includes: ${JSON.stringify([...recursiveIncludes])}`)

--- a/test/scan-includes.js
+++ b/test/scan-includes.js
@@ -84,4 +84,19 @@ suite('scanIncludes', function () {
                 "single.html",
             ]);
     });
+    test('Separate spec directory with includes', async function() {
+        assert.deepStrictEqual(await scanIncludes("https://github.example/repo/", "spec/index.bs", "bikeshed", fakeFetch({
+            "https://github.example/repo/spec/index.bs": { body: "path: helper.inc" },
+            "https://github.example/repo/spec/helper.inc": { body: "path: helper2.inc" },
+            "https://github.example/repo/spec/helper2.inc": { body: "path: subdir/helper3.inc" },
+            "https://github.example/repo/spec/subdir/helper3.inc": { body: "path: subdir/helper4.inc" },
+            "https://github.example/repo/spec/subdir/helper4.inc": { body: "" },
+        })),
+            [
+                "spec/helper.inc",
+                "spec/helper2.inc",
+                "spec/subdir/helper3.inc",
+                "spec/subdir/helper4.inc",
+            ]);
+    });
 });


### PR DESCRIPTION
Bikeshed and ReSpec includes are relative to the root spec file, which might be in a separate directory. This change computes that directory, if any, and prepends it to scanned included files.

Fixes #88. 