### PR TITLE
Refresh PR bodies "Just In Time", to avoid racey edits

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -163,6 +163,8 @@ class Controller {
         if (this.needsUpdate(pr, result)) {
             result.needsUpdate = true;
             return pr.cacheAll().then(_ => {
+                return pr.refreshBody();
+            }).then(_ => {
                 let newBod = this.render(pr);
                 result.needsUpdate = pr.body != newBod.trim();
                 result.content = newBod;

--- a/lib/models/pr.js
+++ b/lib/models/pr.js
@@ -47,6 +47,7 @@ class PR {
     requestPR() {
         return this.request(GH_API.GET_PR).then(payload => {
             this.payload = payload;
+            this.initial_updated_at = payload.updated_at;
             if (this.isMerged) {
                 let err = new Error("PR is already merged.");
                 err.prMerged = true;
@@ -182,6 +183,17 @@ class PR {
 
     get body() {
         return this._body = this._body || (this.payload.body || "").replace(/\r\n/g, "\n").trim();
+    }
+
+    refreshBody() {
+        return this.request(GH_API.GET_PR).then(payload => {
+            let current_updated_at = payload.updated_at;
+            if (this.initial_updated_at !== current_updated_at) {
+                console.log(`PR body was edited during processing (${this.initial_updated_at} -> ${current_updated_at})`);
+            }
+            this._body = (payload.body || "").replace(/\r\n/g, "\n").trim();
+            this.payload.body = payload.body;
+        });
     }
 
     get processor() {

--- a/test/models/pr.js
+++ b/test/models/pr.js
@@ -119,5 +119,25 @@ const BODY = `* Extract legacy callback interface objects
         pr.config = { type: "Bikeshed" };
         assert.equal(pr.processor, "bikeshed");
     });
+
+    test("refreshBody() updates body with latest content", function(done) {
+        let pr = new PR("heycam/webidl/283", { id: 234 });
+        pr.payload = JSON.parse(JSON.stringify(payload.pull_request));
+        pr.initial_updated_at = "2017-02-06T12:39:02Z";
+
+        // Mock the request method to simulate fetching updated PR
+        pr.request = function() {
+            return Promise.resolve({
+                body: "Updated body content",
+                updated_at: "2017-02-06T13:00:00Z"
+            });
+        };
+
+        pr.refreshBody().then(_ => {
+            assert.equal(pr.body, "Updated body content");
+            assert.equal(pr.payload.body, "Updated body content");
+            done();
+        }).catch(done);
+    });
 });
 


### PR DESCRIPTION
The duration of the build can result in a long window of time between the point in time when the PR comment body was initially fetched, to the time it was updated at. This can cause issues if users try to update the issue body while the build is processing.

Steps to reproduce:

1. Make a PR in e.g. whatwg/html
2. Edit the comment.
3. Edit it again within ~1minute
4. Notice that your second edit has been removed and replaced with the contents of the first comment, plus the rendered body.

This change implements functionality to refresh the body right at the point where the change list is rendered. This wont eliminate the problem but should sufficiently minimise the window of time between the build start and the time at which the comment data was fetched to hopefully render this issue hard to reproduce.