### PR TITLE
Add race condition handling for PR builds

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,6 +5,7 @@ const ViewBody = require("./views/body");
 const ViewError = require("./views/error");
 const Config = require("./models/config");
 const github = require("simple-github");
+const { isInternalError } = require("./utils/error-utils");
 
 class Controller {
     constructor() {
@@ -149,8 +150,7 @@ class Controller {
 
     shouldReportError(pr, result) {
         return process.env.NODE_ENV == "production" &&
-            !result.error.noConfig &&
-            !result.error.aborted &&
+            !isInternalError(result.error) &&
             this.needsUpdate(pr, result);
     }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -105,7 +105,6 @@ class Controller {
         result.updated = false;
         result.config = undefined;
         result.previous = undefined;
-        let pr = new PR(result.id, { id: result.installation_id });
         
         console.log("Currently running:", [...this.currently_running]);
         if (this.currently_running.has(result.id)) {
@@ -113,6 +112,8 @@ class Controller {
             result.error.raceCondition = true;
             return Promise.resolve(result);
         }
+        
+        let pr = new PR(result.id, { id: result.installation_id });
         this.currently_running.add(pr.id);
         
         return pr.init({ debug: process.env.DEBUG_SIMPLE_GITHUB == "yes" }).then(_ => {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -94,15 +94,16 @@ class Controller {
         return this.handlePullRequest({
             installation_id: payload.installation.id,
             id:              `${payload.pull_request.base.repo.full_name}/${payload.number}`,
-            forcedUpdate:    !!force,
-            needsUpdate:     undefined,
-            updated:         false,
-            config:          undefined,
-            previous:        undefined
+            forcedUpdate:    !!force
         });
     }
 
     handlePullRequest(result) {
+        // Better logs
+        result.needsUpdate = undefined;
+        result.updated = false;
+        result.config = undefined;
+        result.previous = undefined;
         let pr = new PR(result.id, { id: result.installation_id });
         
         console.log("Currently running:", [...this.currently_running]);
@@ -126,6 +127,14 @@ class Controller {
                 return this.reportError(pr, result).then(_ => this.release(result));
             }            
             return this.release(result);
+        }).then(result => {
+          if (result.requeue) {
+            return this.handlePullRequest({
+                installation_id: result.installation_id,
+                id:              result.id,
+                forcedUpdate:    result.forcedUpdate
+            });
+          }
         });
     }
 
@@ -163,6 +172,22 @@ class Controller {
         if (this.needsUpdate(pr, result)) {
             result.needsUpdate = true;
             return pr.cacheAll().then(_ => {
+                // Check for changes that occurred during build
+                return pr.checkForChanges();
+            }).then(changeInfo => {
+                if (changeInfo.hasCommitChanges) {
+                    result.aborted = true;
+                    result.error = new Error("New commits pushed during build");
+                    result.requeue = true;
+                    return result;
+                }
+
+                if (changeInfo.hasBodyChanges) {
+                    // Update the cached body to use latest content
+                    pr.body = changeInfo.currentBody;
+                    result.bodyChanged = true;
+                }
+
                 let newBod = this.render(pr);
                 result.needsUpdate = pr.body != newBod.trim();
                 result.content = newBod;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -148,7 +148,10 @@ class Controller {
     }
 
     shouldReportError(pr, result) {
-        return !result.error.noConfig && process.env.NODE_ENV == "production" && this.needsUpdate(pr, result);
+        return process.env.NODE_ENV == "production" &&
+            !result.error.noConfig &&
+            !result.error.aborted &&
+            this.needsUpdate(pr, result);
     }
 
     render(pr) {
@@ -176,10 +179,10 @@ class Controller {
                 return pr.checkForChanges();
             }).then(changeInfo => {
                 if (changeInfo.hasCommitChanges) {
-                    result.error = new Error("New commits pushed during build");
-                    result.error.aborted = true;
                     result.requeue = true;
-                    return result;
+                    const err = new Error("New commits pushed during build");
+                    err.aborted = true;
+                    throw err;
                 }
 
                 if (changeInfo.hasBodyChanges) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -176,8 +176,8 @@ class Controller {
                 return pr.checkForChanges();
             }).then(changeInfo => {
                 if (changeInfo.hasCommitChanges) {
-                    result.aborted = true;
                     result.error = new Error("New commits pushed during build");
+                    result.error.aborted = true;
                     result.requeue = true;
                     return result;
                 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ function createLogger(config) {
         // These are well understood error paths.
         // They shouldn't trigger error messages.
         // Log and exit.
-        if (err.noConfig || err.prMerged || err.raceCondition || r.aborted) {
+        if (err.noConfig || err.prMerged || err.raceCondition || err.aborted) {
             logArgs(`${r.id}: ${ action } (${err.message})`);
             return;
         }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 "use strict";
+const { isInternalError } = require("./utils/error-utils");
 
 function createLogger(config) {
     function logArgs() {
@@ -21,7 +22,7 @@ function createLogger(config) {
         // These are well understood error paths.
         // They shouldn't trigger error messages.
         // Log and exit.
-        if (err.noConfig || err.prMerged || err.raceCondition || err.aborted) {
+        if (isInternalError(err)) {
             logArgs(`${r.id}: ${ action } (${err.message})`);
             return;
         }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ function createLogger(config) {
         // These are well understood error paths.
         // They shouldn't trigger error messages.
         // Log and exit.
-        if (err.noConfig || err.prMerged || err.raceCondition) {
+        if (err.noConfig || err.prMerged || err.raceCondition || r.aborted) {
             logArgs(`${r.id}: ${ action } (${err.message})`);
             return;
         }

--- a/lib/models/pr.js
+++ b/lib/models/pr.js
@@ -184,6 +184,10 @@ class PR {
         return this._body = this._body || (this.payload.body || "").replace(/\r\n/g, "\n").trim();
     }
 
+    set body(value) {
+        this._body = value;
+    }
+
     get processor() {
         return this.config.type.toLowerCase();
     }
@@ -258,6 +262,26 @@ class PR {
             .then(_ => {
                 if (this.wattsi) { return this.wattsi.cleanup(); }
             });
+    }
+
+    checkForChanges() {
+        // Make fresh API call to get current PR state
+        return this.request(GH_API.GET_PR).then(currentPayload => {
+            const initialHeadSha = this.payload.head.sha;
+            const initialBody = this.body;
+
+            const currentHeadSha = currentPayload.head.sha;
+            const currentBody = (currentPayload.body || "").replace(/\r\n/g, "\n").trim();
+
+            return {
+                hasCommitChanges: initialHeadSha !== currentHeadSha,
+                hasBodyChanges: initialBody !== currentBody,
+                currentHeadSha: currentHeadSha,
+                currentBody: currentBody,
+                initialHeadSha: initialHeadSha,
+                initialBody: initialBody
+            };
+        });
     }
 }
 

--- a/lib/utils/error-utils.js
+++ b/lib/utils/error-utils.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function isInternalError(error) {
+    return error.noConfig || error.prMerged || error.raceCondition || error.aborted;
+}
+
+module.exports = { isInternalError };


### PR DESCRIPTION
Detect and handle changes that occur during long-running PR builds using HEAD SHA and body comparison via fresh GitHub API calls.

When commits are pushed during build: abort and re-queue with fresh data
When only PR description is edited: preserve user content and continue